### PR TITLE
Added draft support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var GitHubApi = require('@octokit/rest')
 // Pass commit data into this function to format a markdown commit note.
 // Data structure is based on what Github's compare endpoint returns.
 function formatNotes(data){
-	return data.map(commit => `- [${commit.author.login}](${commit.author.html_url}) ${commit.commit.message} [${commit.sha}](${commit.html_url})`).join('\n')
+	return data.map(commit => `- [:information_source:](${commit.html_url}) - ${commit.commit.message} - [${commit.author.login}](${commit.author.html_url})`).join('\n')
 }
 
 // This function generates a date-based version number.

--- a/index.js
+++ b/index.js
@@ -1,69 +1,12 @@
-var GitHubApi = require('github')
+var GitHubApi = require('@octokit/rest')
 
-/*
-
-# formatNotes()
-
-Pass commit data into this function to format a markdown commit note. Data structure is based on what Github's compare endpoint returns.
-
-Example data:
-
-var dataExample = [{
-	author: {
-		login: 'brandonsheppard',
-		html_url: 'https://github.com/brandonsheppard'
-	},
-	commit: {
-		message: 'Etiam porta sem malesuada magna mollis euismod.'
-	},
-	sha: '685eb53d517a335d0d7a654472c9553679161ec8',
-	html_url: 'https://github.com/my_repository/685eb53d517a335d0d7a654472c9553679161ec8'
-},{
-	author: {
-		login: 'philconnah',
-		html_url: 'https://github.com/philconnah'
-	},
-	commit: {
-		message: 'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.'
-	},
-	sha: 'e34784dcbc43873c6900803db2e29c3555830e59',
-	html_url: 'https://github.com/my_repository/e34784dcbc43873c6900803db2e29c3555830e59'
-}]
-
-Example output:
-
-- [brandonsheppard](https://github.com/brandonsheppard) Etiam porta sem malesuada magna mollis euismod. [685eb53d517a335d0d7a654472c9553679161ec8](https://github.com/my_repository/685eb53d517a335d0d7a654472c9553679161ec8)
-- [philconnah](https://github.com/philconnah) Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. [e34784dcbc43873c6900803db2e29c3555830e59](https://github.com/my_repository/e34784dcbc43873c6900803db2e29c3555830e59)
-
-*/
-
+// Pass commit data into this function to format a markdown commit note.
+// Data structure is based on what Github's compare endpoint returns.
 function formatNotes(data){
 	return data.map(commit => `- [${commit.author.login}](${commit.author.html_url}) ${commit.commit.message} [${commit.sha}](${commit.html_url})`).join('\n')
 }
 
-/*
-
-# generateVersionNumber()
-
-This function generates a date-based version number.
-
-Year + Month + Iteration
-
-So, the first release in March 2017 will be 17.3.0
-
-If multiple releases occur in a month, the final number will increase. Otherwise, an entirely new verion number will be generated.
-
-i.e.
-generateVersionNumber('17.12.10');
-
-Output:
-
-Given that the date is 2017-12-01 (day is irrelevant)
-
-17.12.11
-
-*/
-
+// This function generates a date-based version number.
 function generateVersionNumber(previousVersion){
 	let today = new Date();
 	var newMajor = `${today.getFullYear()}.${parseInt(today.getMonth()) + 1}`
@@ -79,11 +22,9 @@ function generateVersionNumber(previousVersion){
 	return newVersion;
 }
 
-
 /* --------------- */
 
 var github = new GitHubApi();
-
 var releaseData = {
 	username: process.argv[2],
 	password: process.argv[3],
@@ -92,6 +33,7 @@ var releaseData = {
 		owner: process.argv[4],
 		name: process.argv[5]
 	},
+	'draft': process.argv[6] == 'draft' ? true : false,
 	name: ''
 }
 
@@ -121,6 +63,7 @@ github.repos.getLatestRelease({
 			repo: releaseData.repository.name,
 			tag_name: generateVersionNumber(releaseData.base),
 			name: generateVersionNumber(releaseData.base) + ' ' + releaseData.name,
+			draft: releaseData.draft,
 			body: `# All Changes \n${formatNotes(res.data.commits)}`
 		}).then(res =>
 			console.log(res)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,82 +1,113 @@
 {
-  "requires": true,
+  "name": "simple-github-release",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@octokit/rest": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.2.0.tgz",
+      "integrity": "sha512-Dn56HRk3445JiZOHIKNWyLjfm3DEWEOfomcfON8Fm6mV+aFtzntuEmcnUIHHdIL7RPuMAFF3aE74CXMW+JpA2w==",
+      "dev": true,
+      "requires": {
+        "before-after-hook": "1.1.0",
+        "btoa-lite": "1.0.0",
+        "debug": "3.1.0",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.0",
+        "lodash": "4.17.5",
+        "node-fetch": "2.1.1",
+        "url-template": "2.0.8"
+      }
+    },
     "agent-base": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "dev": true,
       "requires": {
         "es6-promisify": "5.0.0"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+      "dev": true
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
     },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
     "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
-        "es6-promise": "4.2.2"
+        "es6-promise": "4.2.4"
       }
     },
-    "github": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/github/-/github-13.0.1.tgz",
-      "integrity": "sha512-rApJzcnzy6E3WXhjGlSeRlWKnKM/yoi0fAxNjcOuq+1fjX4dMsiS/AWakrrhpMV3ZHi+mbNgNopS5d3go2AopQ==",
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "dotenv": "4.0.0",
-        "https-proxy-agent": "2.1.1",
-        "lodash": "4.17.4",
-        "proxy-from-env": "1.0.0",
-        "url-template": "2.0.8"
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
       }
     },
     "https-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+      "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+      "dev": true,
       "requires": {
-        "agent-base": "4.1.2",
+        "agent-base": "4.2.0",
         "debug": "3.1.0"
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
-    "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+    "node-fetch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
+      "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ=",
+      "dev": true
     },
     "url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "simple-github-release",
+  "version": "1.0.0",
+  "description": "This script will create a release for a specified Github repository. It will generate a version number (based on [chronological versioning](https://gist.github.com/brandonsheppard/d242ba4ba99923d332f1afdcfa4fbf86)) and release notes ([based on commit history](https://gist.github.com/brandonsheppard/548a4cff7bc1a63e69397cb82269405b)).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brandonsheppard/simple-github-release.git"
+  },
+  "author": "Brandon Sheppard",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/brandonsheppard/simple-github-release/issues"
+  },
+  "homepage": "https://github.com/brandonsheppard/simple-github-release#readme",
+  "devDependencies": {
+    "@octokit/rest": "^15.2.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -5,5 +5,67 @@ This script will create a release for a specified Github repository. It will gen
 ## Usage
 
 ```
-node index.js USERNAME PASSWORD REPO_OWNER_USERNAME REPO_NAME
+node index.js <USERNAME> <PASSWORD> <REPO_OWNER_USERNAME> <REPO_NAME> [draft]
 ```
+
+## Params
+
+- USERNAME - Github username **required**
+- PASSWORD - Github password **required**
+- REPO_OWNER_USERNAME - Owner of the Github repo username **required**
+- REPO_NAME - Github repo name **required**
+- draft - Make a draft release instead of a public release, not including this will make the release public **optional**
+
+## Functions
+
+### formatNotes()
+
+Pass commit data into this function to format a markdown commit note. Data structure is based on what Github's compare endpoint returns.
+
+Example data:
+
+```
+var dataExample = [{
+	author: {
+		login: 'brandonsheppard',
+		html_url: 'https://github.com/brandonsheppard'
+	},
+	commit: {
+		message: 'Etiam porta sem malesuada magna mollis euismod.'
+	},
+	sha: '685eb53d517a335d0d7a654472c9553679161ec8',
+	html_url: 'https://github.com/my_repository/685eb53d517a335d0d7a654472c9553679161ec8'
+},{
+	author: {
+		login: 'philconnah',
+		html_url: 'https://github.com/philconnah'
+	},
+	commit: {
+		message: 'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.'
+	},
+	sha: 'e34784dcbc43873c6900803db2e29c3555830e59',
+	html_url: 'https://github.com/my_repository/e34784dcbc43873c6900803db2e29c3555830e59'
+}]
+```
+
+Example output:
+
+```
+[brandonsheppard](https://github.com/brandonsheppard) Etiam porta sem malesuada magna mollis euismod. [685eb53d517a335d0d7a654472c9553679161ec8](https://github.com/my_repository/685eb53d517a335d0d7a654472c9553679161ec8)
+
+[philconnah](https://github.com/philconnah) Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. [e34784dcbc43873c6900803db2e29c3555830e59](https://github.com/my_repository/e34784dcbc43873c6900803db2e29c3555830e59)
+```
+
+### generateVersionNumber()
+
+This function generates a date-based version number.
+
+- Year + Month + Iteration
+
+So, the first release in March 2017 would be `17.3.0`
+
+#### Multiple releases per month
+
+If multiple releases occur in a month, the final number will increase. Otherwise, an entirely new version number will be generated. i.e: `generateVersionNumber('17.12.10');`
+
+Given that the date is 2017-12-01 (day is irrelevant) and there has already been a release this month: `17.12.11`


### PR DESCRIPTION
Now this can send as a draft release so it can be triggered before it goes live or/and if it needs to get checked on Github. The draft param is optional and if omitted, the release will be published.

`node index.js <USERNAME> <PASSWORD> <REPO_OWNER_USERNAME> <REPO_NAME> [draft]`

Updated readme to have documentation on params and used functions.

---

Quick side note this doesn't work if this is the first release as it checks for `getLatestRelease`, would be cool to check if there is a release, and if not allow this to be the first release.