### PR TITLE
changed repo to use github token authenticate instead of basic authenticate

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,21 +26,19 @@ function generateVersionNumber(previousVersion){
 
 var github = new GitHubApi();
 var releaseData = {
-	username: process.argv[2],
-	password: process.argv[3],
+	token: process.argv[2],
 	base: '',
 	repository: {
-		owner: process.argv[4],
-		name: process.argv[5]
+		owner: process.argv[3],
+		name: process.argv[4]
 	},
-	'draft': process.argv[6] == 'draft' ? true : false,
+	'draft': process.argv[5] == 'draft' ? true : false,
 	name: ''
 }
 
 github.authenticate({
-	type: 'basic',
-	username: releaseData.username,
-	password: releaseData.password
+	type: 'token',
+	token: releaseData.token
 })
 
 function setBase(n){

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,12 @@ This script will create a release for a specified Github repository. It will gen
 ## Usage
 
 ```
-node index.js <USERNAME> <PASSWORD> <REPO_OWNER_USERNAME> <REPO_NAME> [draft]
+node index <TOKEN> <REPO_OWNER_USERNAME> <REPO_NAME> [draft]
 ```
 
 ## Params
 
-- USERNAME - Github username **required**
-- PASSWORD - Github password **required**
+- TOKEN - Github Personal access tokens - https://github.com/settings/tokens **required**
 - REPO_OWNER_USERNAME - Owner of the Github repo username **required**
 - REPO_NAME - Github repo name **required**
 - draft - Make a draft release instead of a public release, not including this will make the release public **optional**


### PR DESCRIPTION
Tested on precision theme and made a successful draft release.

Instead of adding username/password, developer can place in their personal access token, found here:
- https://github.com/settings/tokens

I created a token with full access to repo for my test.